### PR TITLE
remove main as default value for branch

### DIFF
--- a/actions.html
+++ b/actions.html
@@ -134,7 +134,7 @@
     <div class="form-group row my-2">
       <label for="branchName" vanilla-i18n="actions.branchName" class="col-sm-3 col-form-label">Nom de la branche principale</label>
       <div class="col-sm-9">
-        <input type="text" name="branchName" class="form-control" id="branchName" placeholder="main" required="true" value="main" aria-describedby="branchNameHelp">
+        <input type="text" name="branchName" class="form-control" id="branchName" required="true" aria-describedby="branchNameHelp">
         <div id="branchNameHelp" class="form-text"><p vanilla-i18n="actions.branchNameHelp" style="text-align: justify;">Generaly <code>main</code> or <code>master</code>.</p></div>
       </div>
     </div>


### PR DESCRIPTION
`main` is not a default value for the main/master branch in the `actions.html` form. Users are therefore forced to fill the cell with the correct value.