### PR TITLE
Correct typo | Update htr-united_i18n.csv

### DIFF
--- a/assets/vanilla-i18n/htr-united_i18n.csv
+++ b/assets/vanilla-i18n/htr-united_i18n.csv
@@ -32,7 +32,7 @@ main.btn.cite,Cite HTR-United,Citer HTR-United
 main.btn.generate,Record a dataset,Enregistrer un dataset
 
 cat.title,Catalog,Catalogue
-cat.nota,The languages used to introduce the datasets depend on language used by the author(s) of a descripion.,La langue utilisée pour la description des jeux de données correspond à celle employée lors du dépôt d'un signalement dans HTR-United.
+cat.nota,The languages used to introduce the datasets depend on language used by the author(s) of a description.,La langue utilisée pour la description des jeux de données correspond à celle employée lors du dépôt d'un signalement dans HTR-United.
 cat.resultCount,Number of results,Nombre de résultats
 cat.filters,Filters,Filtres
 cat.filters,Filters,Filtres


### PR DESCRIPTION
Fix typo in catalog page

<img width="815" height="117" alt="Screenshot from 2026-01-14 12-19-01" src="https://github.com/user-attachments/assets/81e3f072-1e5d-46ca-a313-66f9cbd7fc4f" />
